### PR TITLE
made buckets page mobile friendly, added maxWidth: '90%' to sx props

### DIFF
--- a/website/src/components/BinTable.js
+++ b/website/src/components/BinTable.js
@@ -3,8 +3,8 @@ import { TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody
 export default function BinTable({ title, col1, col2, rows, keys }){
     return(
         <>
-            <Box sx={{width: 500, maxWidth:'90%'}}>
-                <Typography variant='h6' component='div' sx={{ m: 2, fontWeight: 500,  textAlign:'center'  }}>{title}</Typography>
+            <Box sx={{width: 500, maxWidth: '90%'}}>
+                <Typography variant='h6' component='div' sx={{ m: 2, fontWeight: 500, textAlign: 'center'}}>{title}</Typography>
                 <TableContainer component={Paper} sx={{ maxWidth: 500, height: 'fit-content' }}>
                     <Table>
                         <TableHead>

--- a/website/src/components/BinTable.js
+++ b/website/src/components/BinTable.js
@@ -3,8 +3,8 @@ import { TableContainer, Paper, Table, TableHead, TableRow, TableCell, TableBody
 export default function BinTable({ title, col1, col2, rows, keys }){
     return(
         <>
-            <Box sx={{width:500}}>
-                <Typography variant='h6' component='div' sx={{ m: 2, fontWeight: 500 }}>{title}</Typography>
+            <Box sx={{width: 500, maxWidth:'90%'}}>
+                <Typography variant='h6' component='div' sx={{ m: 2, fontWeight: 500,  textAlign:'center'  }}>{title}</Typography>
                 <TableContainer component={Paper} sx={{ maxWidth: 500, height: 'fit-content' }}>
                     <Table>
                         <TableHead>

--- a/website/src/components/GradeGrid.js
+++ b/website/src/components/GradeGrid.js
@@ -24,7 +24,7 @@ export default function GradeGrid({ category, assignments }) {
 
     
   return ( 
-      <Grid xs={2} sm={4} md={4}>
+      <Grid xs={2} sm={4} md={4} sx={{maxWidth:'90%'}}>
           <GradeTable assignments={assignments} headerLeft={category} headerRight={headerRight} />
       </Grid>
   );

--- a/website/src/components/GradeGrid.js
+++ b/website/src/components/GradeGrid.js
@@ -24,7 +24,7 @@ export default function GradeGrid({ category, assignments }) {
 
     
   return ( 
-      <Grid xs={2} sm={4} md={4} sx={{maxWidth:'90%'}}>
+      <Grid xs={2} sm={4} md={4}>
           <GradeTable assignments={assignments} headerLeft={category} headerRight={headerRight} />
       </Grid>
   );

--- a/website/src/components/ProjectionTable.js
+++ b/website/src/components/ProjectionTable.js
@@ -11,8 +11,8 @@ export default function ProjectionTable({ projections: { zeros, pace, perfect },
     }
     return(
         <>
-        <Box>
-            <TableContainer component={Paper} sx={{maxWidth:500, height:'fit-content'}}>
+        <Box sx={{width:500, maxWidth:'90%'}}>
+            <TableContainer component={Paper} sx={{height:'fit-content'}}>
                 <Table>
                     <TableHead>
                         <TableRow>

--- a/website/src/views/buckets.js
+++ b/website/src/views/buckets.js
@@ -6,6 +6,7 @@ import Loader from '../components/Loader';
 import ProjectionTable from '../components/ProjectionTable';
 
 export default function Buckets(){
+
     const minMedia = useMediaQuery('(min-width:600px)');
     const [binRows, setBins] = useState([]);
     const [loadCount, setLoadCount] = useState(0);
@@ -78,7 +79,7 @@ export default function Buckets(){
                 </Box>
                 { localStorage.getItem('token') &&
                     <>
-                    <Typography variant='h5' component='div' sx={{mt:6, mb:1, fontWeight:500, textAlign:'center'}}>Grade Projections</Typography>
+                    <Typography variant='h5' component='div' sx={{mt:6, mb:2, fontWeight:500, textAlign:'center'}}>Grade Projections</Typography>
                     <Box sx={{mb:4, display:'flex', flexBasis:'min-content', justifyContent:'center'}}>
                         <ProjectionTable projections={projections} gradeData={gradeData} />
                     </Box>


### PR DESCRIPTION
-added maxWidth prop for mobile view
-centered titles
-changed bottom padding for Grade Projections Title to match other bucket bins
-Grade Projections Box added sx={{width:500, maxWidth:'90%'}} to match width of other bins in mobile view