### PR TITLE
[FIX] Make Single Table Look Decent

### DIFF
--- a/website/src/components/GradeGrid.js
+++ b/website/src/components/GradeGrid.js
@@ -24,7 +24,7 @@ export default function GradeGrid({ category, assignments }) {
 
     
     return ( 
-        <Grid xs={2} sm={4} md={4}>
+        <Grid xs={2} sm={4} md={4} sx={{minWidth:'20%'}}>
             <GradeTable assignments={assignments} headerLeft={category} headerRight={headerRight} />
         </Grid>
     );

--- a/website/src/views/home.js
+++ b/website/src/views/home.js
@@ -155,8 +155,8 @@ function Home() {
                             ))}
                         </>
                        : 
-                        <Box sx={{display:'flex', flexDirection:'column', alignItems:'center', marginTop:4} }>                            
-                            <Grid container spacing={{ xs: 3, md: 5 }} columns={{ xs: 4, sm: 8, md: 12 }}>
+                        <Box sx={{display:'flex', flexDirection:'column', alignItems:'center', marginTop:4, width: '100%'}}>                            
+                            <Grid container sx={{width:'100%'}} spacing={{ xs: 3, md: 5 }} columns={{ xs: 4, sm: 8, md: 12 }}>
                                 {accordionTabs.map((assignmentType) => (
                                     <GradeGrid
                                         key={assignmentType}


### PR DESCRIPTION
If there is only one table being rendered on the grades pages it gets squashed so this is a temporary change to make it look somewhat decent.