### PR TITLE
[FEAT] Add API Route to Get Concept Map Query String

### DIFF
--- a/api/assets/progressReport/CS10.json
+++ b/api/assets/progressReport/CS10.json
@@ -1,0 +1,112 @@
+{
+    "name": "CS10",
+    "term": "Spring 2024",
+    "start date": "1/15/2024",
+    "class levels": [
+        {
+            "name": "Taught",
+            "color": "#228B22"
+        },
+        {
+            "name": "Not Taught",
+            "color": "#808080"
+        }
+    ],
+    "student levels": [
+        {
+            "name": "First Steps",
+            "color": "#757C88"
+        },
+        {
+            "name": "Needs Practice",
+            "color": "#ADD8E6"
+        },
+        {
+            "name": "In Progress",
+            "color": "#89CFF0"
+        },
+        {
+            "name": "Almost There",
+            "color": "#6495ED"
+        },
+        {
+            "name": "Mastered",
+            "color": "#0F4D92"
+        }
+    ],
+    "count": 8,
+    "nodes": {
+        "id": 1,
+        "name": "CS10",
+        "parent": "null",
+        "children": [
+            {
+                "id": 2,
+                "name": "Quest",
+                "parent": "null",
+                "children": [
+                    {
+                        "id": 3,
+                        "name": "Abstraction",
+                        "parent": "Quest",
+                        "children": [],
+                        "data": {
+                            "week": 4
+                        }
+                    },
+                    {
+                        "id": 4,
+                        "name": "Iteration",
+                        "parent": "Quest",
+                        "children": [],
+                        "data": {
+                            "week": 5
+                        }
+                    },
+                    {
+                        "id": 5,
+                        "name": "Functions",
+                        "parent": "Quest",
+                        "children": [],
+                        "data": {
+                            "week": 5
+                        }
+                    },
+                    {
+                        "id": 6,
+                        "name": "HOF",
+                        "parent": "Quest",
+                        "children": [],
+                        "data": {
+                            "week": 12
+                        }
+                    },
+                    {
+                        "id": 7,
+                        "name": "Domain",
+                        "parent": "Quest",
+                        "children": [],
+                        "data": {
+                            "week": 13
+                        }
+                    },
+                    {
+                        "id": 8,
+                        "name": "Range",
+                        "parent": "Quest",
+                        "children": [],
+                        "data": {
+                            "week": 15
+                        }
+                    }
+                ],
+                "data": {
+                    "week": 2
+                }
+            }
+        ],
+        "data": {
+            "week": 0
+        }
+    }
+}

--- a/api/server.js
+++ b/api/server.js
@@ -6,6 +6,8 @@ import esMain from 'es-main';
 import config from 'config';
 import dotenv from 'dotenv';
 
+import ProgressReportData from './assets/progressReport/CS10.json' assert {type: 'json'};
+
 class AuthenticationError extends Error{}
 class UnauthorizedAccessError extends Error{}
 class BadSheetDataError extends Error{}
@@ -302,6 +304,48 @@ async function getBins(apiAuthClient){
     return res.data.values;
 }
 
+/**
+ * Calculates the total amount of points a user has achieved so far for each topic.
+ * @param {Array<object>} userGradeData the total user's grade data.
+ * @returns {object} a dictionary of topics to sum of those grades.
+ */
+function mapTopicsToGrades(userGradeData) {
+    const topicsToGradesTable = {};
+    userGradeData.forEach((assignment) => {
+        if (!(assignment.assignment in topicsToGradesTable)) {
+            topicsToGradesTable[assignment.assignment] = 0;
+        }
+        topicsToGradesTable[assignment.assignment] += +(assignment.grade ?? 0);
+    });
+    return topicsToGradesTable;
+}
+
+/**
+ * Gets the user's progress for each of the topics taught so far.
+ * @param {Promise<Compute | JSONClient | T>} apiAuthClient
+ * @param {string} email the email of the user to look up.
+ */
+async function getProgressReportQueryParameter(apiAuthClient, email){
+    const userGrades = await getUserGrades(apiAuthClient, email);
+    const maxGrades = await getUserGrades(apiAuthClient, MAXGRADEROW);
+    const userTopicPoints = mapTopicsToGrades(userGrades);
+    const maxTopicPoints = mapTopicsToGrades(maxGrades);
+    const numMasteryLevels = ProgressReportData['student levels'].length - 2;
+    Object.entries(userTopicPoints).forEach(([topic, userPoints]) => {
+        const maxAchievablePoints = maxTopicPoints[topic];
+        if (userPoints === 0) {
+            return;
+        }
+        if (userPoints >= maxAchievablePoints) {
+            userTopicPoints[topic] = numMasteryLevels + 1;
+            return;
+        }
+        userTopicPoints[topic] = Math.ceil((userPoints / maxAchievablePoints) * numMasteryLevels);
+    });
+    return Object.values(userTopicPoints).join('');
+}
+
+
 async function main(){
     const app = express();
     app.use(cors());
@@ -311,6 +355,7 @@ async function main(){
         credentials: JSON.parse(process.env.SERVICE_ACCOUNT_CREDENTIALS),
         scopes: SCOPES
     }).getClient();
+
     const oauthClient = new OAuth2Client(OAUTHCLIENTID);
 
     /**
@@ -427,6 +472,18 @@ async function main(){
                 return res.status(502).json({ error: '502: Bad Gateway'});
             }
         }
+    });
+
+    /**
+     * Responds with the logged in user's configured progress report query string.
+     * @param {Request} req authenticated request.
+     * @param {Response} res
+     * @returns {Promise<Response<string>>} the user's progress report query string.
+     */
+    app.get('/api/progressquerystring', async (req, res) => {
+        console.debug('received request');
+        const email = await getEmailFromIdToken(oauthClient, req.headers.authorization.split(' ')[1]);
+        return res.status(200).send(await getProgressReportQueryParameter(apiAuthClient, email));
     });
 
     // Responds with whether or not the current user is an admin

--- a/api/server.js
+++ b/api/server.js
@@ -481,7 +481,6 @@ async function main(){
      * @returns {Promise<Response<string>>} the user's progress report query string.
      */
     app.get('/api/progressquerystring', async (req, res) => {
-        console.debug('received request');
         const email = await getEmailFromIdToken(oauthClient, req.headers.authorization.split(' ')[1]);
         return res.status(200).send(await getProgressReportQueryParameter(apiAuthClient, email));
     });


### PR DESCRIPTION
# Changes

- Added `/api/progressquerystring` endpoint.
- Added example progress report parser data to API.