### PR TITLE
Change grade bins to be in descending order (A+ to F)

### DIFF
--- a/website/src/views/buckets.js
+++ b/website/src/views/buckets.js
@@ -14,17 +14,17 @@ export default function Buckets(){
         let mounted = true;
         setLoadCount(i => i + 1);
         api.get('/bins').then((res) => {
-            if(mounted){
-                let tempBins = [{ grade: res.data[0][1], range: `0-${res.data[0][0]}`}];
-                for(let i = 1; i < res.data.length; i++){
+            if (mounted) {
+                let tempBins = [];
+                for(let i = res.data.length - 1; i >= 0; i--){
                     const grade = res.data[i][1];
-                    const range = `${+res.data[i - 1][0] + 1}-${res.data[i][0]}`;
-                    tempBins = [...tempBins, { grade, range }];
+                    const lower = (i != 0) ? +res.data[i - 1][0] + 1: 0;
+                    const range = `${lower}-${res.data[i][0]}`;
+                    tempBins.push({grade, range});
                 }
                 setBins(tempBins);
             }
         }).finally(() => {
-            console.log("test")
             setLoadCount(i => i - 1);
         });
         return () => mounted = false;


### PR DESCRIPTION
Reversed the grade bins to show possible grade values from A+ to F. Before, the bins were being shown from F to A+. This is because we fetched the rows in order from this spreadsheet https://docs.google.com/spreadsheets/d/1kaCebQXcx0DCu0-FNPbJlmF_XfN8QOOyI4LJxg4_J74/edit#gid=1306410194 where the bins are in ascending order in the spreadsheet. The new changes have the bins for the website in descending order (from A+ to F).
![image](https://github.com/Connor-Bernard/gradeView/assets/48500458/0ff6c3ab-210d-4a58-8b09-fa7195c93943)
