### PR TITLE
Add activeTab highlighting and onHover coloring for tab selection

### DIFF
--- a/website/src/App.js
+++ b/website/src/App.js
@@ -37,11 +37,12 @@ export default function App() {
 	return (
 		<ThemeProvider theme={theme}>
 			<div className="app">
-				<div className="nav">
-					<NavBar />
-				</div>
+
 				<div className="content">
 					<BrowserRouter>
+					<div className="nav" key="mehul">
+					<NavBar />
+				</div>
 						<Routes>
 							<Route exact path='/login' element={localStorage.getItem('token') ? <Navigate to='/' /> : <Login />} />
 							<Route exact path='/buckets' element={<Buckets />} />

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -40,9 +40,9 @@ export default function App() {
 
 				<div className="content">
 					<BrowserRouter>
-					<div className="nav">
-					<NavBar />
-				</div>
+						<div className="nav">
+							<NavBar />
+						</div>
 						<Routes>
 							<Route exact path='/login' element={localStorage.getItem('token') ? <Navigate to='/' /> : <Login />} />
 							<Route exact path='/buckets' element={<Buckets />} />

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -40,7 +40,7 @@ export default function App() {
 
 				<div className="content">
 					<BrowserRouter>
-					<div className="nav" key="mehul">
+					<div className="nav">
 					<NavBar />
 				</div>
 						<Routes>

--- a/website/src/components/NavBarItem.js
+++ b/website/src/components/NavBarItem.js
@@ -1,23 +1,29 @@
 import React from 'react'
-import { Button, Link } from '@mui/material';
+import { Button, Link, Box } from '@mui/material';
 import { NavLink, useMatch } from 'react-router-dom';
 
 export default function NavBarItem({ href, children }){
 
     const match = useMatch(href);
     return (
-        <Link component={NavLink} to={href} color='inherit' underline='none'>
-          <Button
-            color='inherit'
-            sx={{
-              backgroundColor: match ? '#1F7CD5' : 'inherit',
-              '&:hover': {
-                backgroundColor: 'lightblue', 
-              }
-            }}
-          >
+        <Link component={NavLink} to={href} color='inherit' >
+          <Button sx={{ color: 'inherit', opacity: match ? 1 : 0.7 }}>
             {children}
-          </Button>
-        </Link>
-      );
+            {match && (
+              <Box
+                className="underline"
+                sx={{
+                  position: 'absolute',
+                  bottom: 0, // Position at the bottom of the button
+                  left: '50%',
+                  transform: 'translateX(-50%)', // Center the Box
+                  width: '100%',
+                  height: '2px', // Thickness of the underline
+                  backgroundColor: 'currentColor', // Use the text color for the underline
+                }}
+              />
+          )}
+        </Button>
+      </Link>
+    );
 }

--- a/website/src/components/NavBarItem.js
+++ b/website/src/components/NavBarItem.js
@@ -3,7 +3,6 @@ import { Button, Link, Box } from '@mui/material';
 import { NavLink, useMatch } from 'react-router-dom';
 
 export default function NavBarItem({ href, children }){
-
     const match = useMatch(href);
     return (
         <Link component={NavLink} to={href} color='inherit' >

--- a/website/src/components/NavBarItem.js
+++ b/website/src/components/NavBarItem.js
@@ -1,10 +1,23 @@
 import React from 'react'
 import { Button, Link } from '@mui/material';
+import { NavLink, useMatch } from 'react-router-dom';
 
 export default function NavBarItem({ href, children }){
+
+    const match = useMatch(href);
     return (
-        <Link href={href} color='inherit' underline='none'>
-            <Button color='inherit'>{children}</Button>
+        <Link component={NavLink} to={href} color='inherit' underline='none'>
+          <Button
+            color='inherit'
+            sx={{
+              backgroundColor: match ? '#1F7CD5' : 'inherit',
+              '&:hover': {
+                backgroundColor: 'lightblue', 
+              }
+            }}
+          >
+            {children}
+          </Button>
         </Link>
-    );
+      );
 }


### PR DESCRIPTION
Active Tab Highlighting

useMatch examples: https://www.educative.io/answers/how-to-use-usematch-hook-in-react-router

The navbar changed to be inside `BrowserRouter` because `useMatch` and many other hooks needs to be used within a component that is a descendant of `BrowserRouter`.
useMatch relies on the React context provided by BrowserRouter (or another router component) to access the current location and match it against the specified path.

Example
Consider the URL http://example.com/users?active=true&sort=name. In this URL:

The pathname is /users.
The query parameters are active=true&sort=name.
If you use useMatch to check for a match against /users, it will match this URL regardless of the query parameters.

No underlining, but opacity for activeTab is 1, while others is 0.5
![image](https://github.com/Connor-Bernard/gradeView/assets/48500458/b483fc11-2541-4be8-b6d5-5e97a8bb1c44)

New underlining using Material UI's Box component.

This pull request took slightly longer because of communication between teammates on what designs looked the best.
Opacity for activeTab is 1 and non-active tabs is 0.7