### PR TITLE
no auth needed for db access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     build: 
      context: ./database/redis
      dockerfile: Dockerfile
-    command: redis-server --requirepass ${REDIS_DB_SECRET:-password}
+    command: redis-server 
     ports:
       - 6379:6379
   dbcron:


### PR DESCRIPTION
DB Updates part 1:
Removed --requirepass for redis db

Waiting on directions for creating a manual script