### PR TITLE
enable refresh on window resize

### DIFF
--- a/progressReport/templates/web_ui.html
+++ b/progressReport/templates/web_ui.html
@@ -328,6 +328,16 @@
 
         loadCourseData(courseData);
 
+        window.onresize = function() {
+            if (window.RT) {
+                clearTimeout(window.RT);
+            }
+            window.RT = setTimeout(function() {
+                this.location.reload(false);
+            }, 200);
+        };
+
     </script>
+
 </body>
 </html>


### PR DESCRIPTION
Reload and center progress report on window resizing, with a timeout of 200 ms.