### PR TITLE
GradeBins bug on 0 Values and empty values

### DIFF
--- a/website/src/components/GradeTable.js
+++ b/website/src/components/GradeTable.js
@@ -34,7 +34,7 @@ export default function GradeTable({ assignments, headerLeft, headerRight }) {
                                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
                                 <TableCell component='th' scope='assignment' >{concept}</TableCell>
                                 <TableCell align='right' sx={{ fontWeight: isBold(points.student, points.max) }}>
-                                    {`${points.student || points.student === 0 ? points.student : '-'} / ${points.max}`}
+                                    {`${points.student ?? '-'} / ${points.max}`}
                                 </TableCell>
                             </TableRow>
                         ))

--- a/website/src/components/GradeTable.js
+++ b/website/src/components/GradeTable.js
@@ -34,7 +34,7 @@ export default function GradeTable({ assignments, headerLeft, headerRight }) {
                                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
                                 <TableCell component='th' scope='assignment' >{concept}</TableCell>
                                 <TableCell align='right' sx={{ fontWeight: isBold(points.student, points.max) }}>
-                                    {`${points.student || 'N/A'} / ${points.max}`}
+                                    {`${points.student || points.student === 0 ? points.student : '-'} / ${points.max}`}
                                 </TableCell>
                             </TableRow>
                         ))


### PR DESCRIPTION
Change logic to show 0 grade values correctly. If the grade value is the empty string, then '-' is displayed instead, which indicates the assignment has not been graded yet. Empty values on the spreadsheet translate to the empty string in this program.

Previous implementation bug:
![image](https://github.com/Connor-Bernard/gradeView/assets/48500458/79c3670e-c9e8-4343-826d-23c8decc194c)
![image](https://github.com/Connor-Bernard/gradeView/assets/48500458/60fc1a17-0b5c-4904-9973-5b2c60a6951a)

New implementation:
![image](https://github.com/Connor-Bernard/gradeView/assets/48500458/1096bb8c-eb8b-4b90-878f-87f70417c6cb)
![image](https://github.com/Connor-Bernard/gradeView/assets/48500458/55238dcf-c249-454d-ac22-15042c28c9ba)
